### PR TITLE
Add possibility to replace titles

### DIFF
--- a/youtube2zim/entrypoint.py
+++ b/youtube2zim/entrypoint.py
@@ -73,6 +73,13 @@ def main():
     )
 
     parser.add_argument(
+        "--custom_titles",
+        help="Replace titles with the ones retrieved from a csv file",
+        default=False,
+        dest="custom_titles",
+    )
+
+    parser.add_argument(
         "--tmp-dir",
         help="Path to create temp folder in. Used for building ZIM file. Receives all data (storage space)",
     )


### PR DESCRIPTION
Allows to replace video titles with others. The --custom_titles argument expects a csv file path. The file must have a column with the video IDs and another with the titles we want to use.

This was feature-tested on ubuntu 22.10.

cc @holta 